### PR TITLE
counsel--async-command-1: Immediately update minibuffer after spawning

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -241,6 +241,9 @@ respectively."
     (setq counsel--async-start counsel--async-time)
     (set-process-sentinel proc (or sentinel #'counsel--async-sentinel))
     (set-process-filter proc (or filter #'counsel--async-filter))
+    ;; immediately update the display
+    (let ((counsel-async-filter-update-time 0))
+      (funcall (process-filter proc) proc ""))
     proc))
 
 (defcustom counsel-async-command-delay 0


### PR DESCRIPTION
This fixes an issue in counsel-rg and related commands where, if the user quickly types some string that does not have any grep results, and the search takes a long time, then the candidates list will say "1 more chars" while ripgrep is already running and won't be updated until ripgrep exits.